### PR TITLE
Add MultiSelectRelatedOnlyFilter 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,9 @@ Filter classes
     Multi select filter for all kind of fields.
 * **MultiSelectRelatedFilter**
     Multi select filter for relation fields.
+* **MultiSelectRelatedOnlyFilter**
+    Multi select filter for related fields with choices limited to the objects
+    involved in that relation
 * **MultiSelectDropdownFilter**
     Multi select dropdown filter for all kind of fields.
 * **MultiSelectRelatedDropdownFilter**

--- a/more_admin_filters/__init__.py
+++ b/more_admin_filters/__init__.py
@@ -3,7 +3,7 @@ __version__ = ".".join(map(str, VERSION))
 
 
 from .filters import (
-    MultiSelectFilter, MultiSelectRelatedFilter, MultiSelectDropdownFilter,
-    MultiSelectRelatedDropdownFilter, DropdownFilter, ChoicesDropdownFilter,
-    RelatedDropdownFilter, BooleanAnnotationFilter
+    MultiSelectFilter, MultiSelectRelatedFilter, MultiSelectRelatedOnlyFilter,
+    MultiSelectDropdownFilter, MultiSelectRelatedDropdownFilter, DropdownFilter,
+    ChoicesDropdownFilter, RelatedDropdownFilter, BooleanAnnotationFilter
 )

--- a/more_admin_filters/filters.py
+++ b/more_admin_filters/filters.py
@@ -190,6 +190,19 @@ class MultiSelectRelatedFilter(MultiSelectMixin, admin.RelatedFieldListFilter):
             }
 
 
+class MultiSelectRelatedOnlyFilter(MultiSelectRelatedFilter):
+    def field_choices(self, field, request, model_admin):
+        pk_qs = (
+            model_admin.get_queryset(request)
+            .distinct()
+            .values_list("%s__pk" % self.field_path, flat=True)
+        )
+        ordering = self.field_admin_ordering(field, request, model_admin)
+        return field.get_choices(
+            include_blank=False, limit_choices_to={"pk__in": pk_qs}, ordering=ordering
+        )
+
+
 class MultiSelectDropdownFilter(MultiSelectFilter):
     """
     Multi select dropdown filter for all kind of fields.


### PR DESCRIPTION
This `MultiSelectRelatedOnlyFilter` is only inheriting of the current `MultiSelectRelatedFilter` but override the `field_choices` method with Django's `RelatedOnlyFieldListFilter` method.

The current test suit should be enough to keep the coverage. If not, I will add some tests accordingly.

Closes #12 