### PR TITLE
Django 5.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           - python-version: "3.10"
             django-version: Django==4.2
 
+          - python-version: "3.10"
+            django-version: Django==5.0
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ Welcome to django-more-admin-filters
    :target: https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue
    :alt: python: 3.6, 3.7, 3.8, 3.9, 3.10
 
-.. image:: https://img.shields.io/badge/django-2.2%20%7C%203.0%20%7C%203.1%20%7C%203.2%20%7C%204.0%20%7C%204.1%20%7C%204.2-orange
-   :target: https://img.shields.io/badge/django-2.2%20%7C%203.0%20%7C%203.1%20%7C%203.2%20%7C%204.0%20%7C%204.1%20%7C%204.2-orange
-   :alt: django: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2
+.. image:: https://img.shields.io/badge/django-2.2%20%7C%203.0%20%7C%203.1%20%7C%203.2%20%7C%204.0%20%7C%204.1%20%7C%204.2%20%7C%205.0-orange
+   :target: https://img.shields.io/badge/django-2.2%20%7C%203.0%20%7C%203.1%20%7C%203.2%20%7C%204.0%20%7C%204.1%20%7C%204.2%20%7C%205.0-orange
+   :alt: django: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0
 
 
 Description

--- a/README.rst
+++ b/README.rst
@@ -78,11 +78,14 @@ Filter classes
     Multi select filter for relation fields.
 * **MultiSelectRelatedOnlyFilter**
     Multi select filter for related fields with choices limited to the objects
-    involved in that relation
+    involved in that relation.
 * **MultiSelectDropdownFilter**
     Multi select dropdown filter for all kind of fields.
 * **MultiSelectRelatedDropdownFilter**
     Multi select dropdown filter for relation fields.
+* **MultiSelectRelatedOnlyDropdownFilter**
+    Multi select dropdown filter for relation fields with choices limited to the objects
+    involved in that relation.
 * **BooleanAnnotationFilter**
     Filter for annotated boolean-attributes.
 

--- a/more_admin_filters/filters.py
+++ b/more_admin_filters/filters.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import urllib.parse
 from django.contrib.admin.utils import prepare_lookup_value
 from django.contrib import admin
 from django.db.models import Q
@@ -237,7 +238,7 @@ class MultiSelectDropdownFilter(MultiSelectFilter):
                 'selected': qval in self.lookup_vals,
                 'query_string': query_string,
                 'display': val,
-                'value': val,
+                'value': urllib.parse.quote_plus(val),
                 'key': self.lookup_kwarg,
             }
         if include_none:

--- a/more_admin_filters/filters.py
+++ b/more_admin_filters/filters.py
@@ -283,6 +283,10 @@ class MultiSelectRelatedDropdownFilter(MultiSelectRelatedFilter):
             }
 
 
+class MultiSelectRelatedOnlyDropdownFilter(MultiSelectRelatedDropdownFilter, MultiSelectRelatedOnlyFilter):
+    pass
+
+
 # Filter for annotated attributes.
 # NOTE: The code is more or less the same than admin.FieldListFilter but
 # we must not subclass it. Otherwise django's filter setup routine wants a real

--- a/more_admin_filters/filters.py
+++ b/more_admin_filters/filters.py
@@ -141,7 +141,7 @@ class MultiSelectFilter(MultiSelectMixin, admin.AllValuesFieldListFilter):
         return used_parameters
 
     def choices(self, changelist):
-        add_facets = changelist.add_facets
+        add_facets = getattr(changelist, "add_facets", False) 
         facet_counts = self.get_facet_queryset(changelist) if add_facets else None
         yield {
             'selected': not self.lookup_vals and self.lookup_val_isnull is None,
@@ -195,7 +195,7 @@ class MultiSelectRelatedFilter(MultiSelectMixin, admin.RelatedFieldListFilter):
         self.empty_value_display = model_admin.get_empty_value_display()
 
     def choices(self, changelist):
-        add_facets = changelist.add_facets
+        add_facets = getattr(changelist, "add_facets", False) 
         facet_counts = self.get_facet_queryset(changelist) if add_facets else None
         yield {
             'selected': not self.lookup_vals and not self.lookup_val_isnull,
@@ -247,7 +247,7 @@ class MultiSelectDropdownFilter(MultiSelectFilter):
     template = 'more_admin_filters/multiselectdropdownfilter.html'
 
     def choices(self, changelist):
-        add_facets = changelist.add_facets
+        add_facets = getattr(changelist, "add_facets", False) 
         facet_counts = self.get_facet_queryset(changelist) if add_facets else None
         query_string = changelist.get_query_string({}, [self.lookup_kwarg, self.lookup_kwarg_isnull])
         yield {
@@ -292,7 +292,7 @@ class MultiSelectRelatedDropdownFilter(MultiSelectRelatedFilter):
     template = 'more_admin_filters/multiselectdropdownfilter.html'
 
     def choices(self, changelist):
-        add_facets = changelist.add_facets
+        add_facets = getattr(changelist, "add_facets", False) 
         facet_counts = self.get_facet_queryset(changelist) if add_facets else None
         query_string = changelist.get_query_string({}, [self.lookup_kwarg, self.lookup_kwarg_isnull])
         yield {

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_namespace_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=[
-        "Django>=2.2,<5.0",
+        "Django>=2.2,<6.0",
     ],
     classifiers=[
         dev_status,
@@ -54,6 +54,7 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/tests/testapp/tests/test_live_filters.py
+++ b/tests/testapp/tests/test_live_filters.py
@@ -4,6 +4,7 @@ import time
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support.ui import Select
@@ -52,36 +53,36 @@ class FilterPage:
 
     @property
     def item_count(self):
-        return len(self.selenium.find_elements_by_xpath('//*[@id="result_list"]/tbody/tr'))
+        return len(self.selenium.find_elements(By.XPATH, '//*[@id="result_list"]/tbody/tr'))
 
     @property
     def url_query(self):
         return self.selenium.current_url.split('?')[-1].replace('%2C', ',')
 
     def get_selected_li_count(self, ul):
-        return len(ul.find_elements_by_css_selector('li.selected'))
+        return len(ul.find_elements(By.CSS_SELECTOR, 'li.selected'))
 
     def use_dropdown_filter(self, select_id, option):
-        select = Select(self.selenium.find_element_by_id(select_id))
+        select = Select(self.selenium.find_element(By.ID, select_id))
         select.select_by_visible_text(option)
         self.wait_for_reload()
-        return Select(self.selenium.find_element_by_id(select_id))
+        return Select(self.selenium.find_element(By.ID, select_id))
 
     def use_multiselect_filter(self, ul_num, title):
         uls_css = '#changelist-filter ul'
         a_xpath = f'li/a[text() = "{title}"]'
-        ul = self.selenium.find_elements_by_css_selector(uls_css)[ul_num-1]
-        ul.find_element_by_xpath(a_xpath).click()
+        ul = self.selenium.find_elements(By.CSS_SELECTOR, uls_css)[ul_num-1]
+        ul.find_element(By.XPATH, a_xpath).click()
         self.wait_for_reload()
-        return self.selenium.find_elements_by_css_selector(uls_css)[ul_num-1]
+        return self.selenium.find_elements(By.CSS_SELECTOR, uls_css)[ul_num-1]
 
     def use_multiselect_dropdown_filter(self, field, options):
-        select = Select(self.selenium.find_element_by_id(field + '_select'))
+        select = Select(self.selenium.find_element(By.ID, field + '_select'))
         for value in options:
             select.select_by_value(value)
-        self.selenium.find_element_by_id(field + '_submit').click()
+        self.selenium.find_element(By.ID, field + '_submit').click()
         self.wait_for_reload()
-        return Select(self.selenium.find_element_by_id(field + '_select'))
+        return Select(self.selenium.find_element(By.ID, field + '_select'))
 
 
 class LiveFilterTest(StaticLiveServerTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist =
     {py39,py10}-django40
     {py39,py10}-django41
     {py39,py10}-django42
+    {py10}-django50
 
 skip_missing_interpreters = true
 
@@ -24,6 +25,7 @@ deps =
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
     selenium<=4.16.0
 
 commands = {envpython} tests/manage.py test testapp {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
-    selenium<4.3.0
+    selenium<=4.16.0
 
 commands = {envpython} tests/manage.py test testapp {posargs}
 setenv = PYTHONPATH = .:{toxworkdir}


### PR DESCRIPTION
Initial support for Django 5.0 and a few other changes:
* Facet support for all FieldListFilter derived classes _(I wasn't sure what to do with BooleanAnnotationFilter, so I left it as-is)_
* Workaround to `used_parameters` being parsed into nested lists (`flatten_used_parameters` function)
* Updated tests to work with latest Selenium versions
* Bugfix to MultiSelectRelatedDropdownFilter value not being URL encoded (possibly fixes #21 )
* Add MultiSelectRelatedOnlyDropdownFilter