### PR TITLE
Flatten boolean values for __isnull lookups

### DIFF
--- a/more_admin_filters/filters.py
+++ b/more_admin_filters/filters.py
@@ -20,6 +20,9 @@ def flatten_used_parameters(used_parameters: dict, keep_list: bool = True):
     for k, v in used_parameters.items():
         if len(v) == 1 and (isinstance(v[0], list) or not keep_list):
             used_parameters[k] = v[0]
+        elif k.endswith("__isnull") and len(v) == 1 and isinstance(v, list) and isinstance(v[0], bool):
+                used_parameters[k] = v[0]
+
 
 
 # Generic filter using a dropdown widget instead of a list.


### PR DESCRIPTION
**Problem**
When trying to filter from a foreignkey, on null values, django raises the following error :
`The QuerySet value for an isnull lookup must be True or False.
`

This issue occurs when the url filter is like '__isnull' and  the value provided is a unique list containing a single boolean instead of being directly flattened to a boolean. Error is raised by django IsNull @Field.register_lookup

**Solution**
This PR ensures that __isnull lookup values are flattened when:

-> The field type is __isnull.
-> The value is a unique list containing exactly one boolean.

