### PR TITLE
Fix BooleanAnnotationFilter to persist user-selected value

### DIFF
--- a/more_admin_filters/filters.py
+++ b/more_admin_filters/filters.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from django.contrib.admin.utils import reverse_field_path
+from django.contrib.admin.utils import get_last_value_from_parameters
 from django.contrib.admin.utils import get_model_from_relation
 from django.core.exceptions import ValidationError
 from django.contrib.admin.options import IncorrectLookupParameters
@@ -393,8 +394,8 @@ class BooleanAnnotationFilter(BaseAnnotationFilter):
     def __init__(self, request, params, model, model_admin):
         self.lookup_kwarg = '%s__exact' % self.attribute_name
         self.lookup_kwarg2 = '%s__isnull' % self.attribute_name
-        self.lookup_val = params.get(self.lookup_kwarg)
-        self.lookup_val2 = params.get(self.lookup_kwarg2)
+        self.lookup_val = get_last_value_from_parameters(params, self.lookup_kwarg)
+        self.lookup_val2 = get_last_value_from_parameters(params, self.lookup_kwarg2)
         super().__init__(request, params, model, model_admin)
         flatten_used_parameters(self.used_parameters, False)
         if (self.used_parameters and self.lookup_kwarg in self.used_parameters and


### PR DESCRIPTION
I noticed that when I select an option in the filter widget
* the page is refreshed
* param is correctly added to the URL

but the filter widget doesn't display the selected choice.

Traced the problem back to this line:
https://github.com/thomst/django-more-admin-filters/blob/6c7e8a1dd5cdedeb2ab68650bfd90bfc37024965/more_admin_filters/filters.py#L413

`lookup_val` comes as a list and it's compared to `lookup` which is a string. They will never be equal, so the choice is not selected.

I think the class needs an update, similar to what Django did in this commit: https://github.com/django/django/commit/d03dc63177ad3ba6e685e314eed45d6a8ec5cb0c


